### PR TITLE
Fix pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,20 @@
 # Python bindings for Nix using CFFI
 
-Maintainer status: maintained, experimental
+Maintainer status: maintained, experimental.
 
-# Example
+Compatibility: Requires https://github.com/NixOS/nix/pull/8699
 
-```python
-import nix
+## Try in a REPL!
 
-# Load the nixpkgs repository
-pkgs = nix.eval("import nixpkgs")({})
-
-# Get the hello package and override its name
-hello2 = pkgs["hello"]["overrideAttrs"](lambda o: {
-  "pname": str(o["pname"]) + "-test"
-})
-
-# Build the package
-hello2.build()
+```shell
+$ nix develop tweag/python-nix#env
+$ python
+>>> import nix
+>>> nix.eval("1+1")
+<Nix: 2>
 ```
 
-# Add to your project
+## Add to your project
 
 Because this package uses CFFI, it requires a bit more setup than a typical Python package.
 
@@ -41,3 +36,34 @@ You can install using pip:
 $ pip install git+https://github.com/tweag/python-nix.git
 ```
 
+## Example
+
+```python
+import nix
+
+# Load the nixpkgs repository
+pkgs = nix.eval("import nixpkgs")({})
+
+# Get the hello package and override its name
+hello2 = pkgs["hello"]["overrideAttrs"](lambda o: {
+  "pname": str(o["pname"]) + "-test"
+})
+
+# Build the package
+hello2.build()
+```
+
+## Development
+
+### Using Nix
+
+A development environment is available in the provided Nix flake.
+Once in the development environment, run `buildFFI.py` to test your changes.
+
+```shell
+$ nix develop .#
+$ cd src
+$ python buildFFI.py
+$ python
+>>> import nix
+```

--- a/README.md
+++ b/README.md
@@ -1,33 +1,43 @@
 # Python bindings for Nix using CFFI
+
 Maintainer status: maintained, experimental
-Compatibility: Requires https://github.com/NixOS/nix/pull/8699
-
-
-# Getting started
-```shell
-$ nix develop tweag/python-nix#env
-$ python
->>> import nix
->>> nix.eval("1+1")
-<Nix: 2>
->>>
-```
-
-# Hacking
-```shell
-$ nix develop .#
-$ cd src
-$ python buildFFI.py
-$ python
->>> import nix
-```
 
 # Example
+
 ```python
 import nix
+
+# Load the nixpkgs repository
 pkgs = nix.eval("import nixpkgs")({})
+
+# Get the hello package and override its name
 hello2 = pkgs["hello"]["overrideAttrs"](lambda o: {
   "pname": str(o["pname"]) + "-test"
 })
+
+# Build the package
 hello2.build()
 ```
+
+# Add to your project
+
+Because this package uses CFFI, it requires a bit more setup than a typical Python package.
+
+To install this package, you will need:
+* gcc
+* pkg-config
+
+and a specific branch of Nix from https://github.com/NixOS/nix/pull/8699 that can be caught by pkg-config.
+
+You can build it and give it to pkg-config by running:
+
+```shell
+$ export PKG_CONFIG_PATH="$(nix build github:tweag/nix/nix-c-bindings#default.dev --no-link --print-out-paths)/lib/pkgconfig"
+```
+
+You can install using pip:
+
+```shell
+$ pip install git+https://github.com/tweag/python-nix.git
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "cffi>=1.0.0", "pkgconfig>=1.5.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -18,7 +18,6 @@ classifiers = [
     "Topic :: Software Development :: Interpreters",
     "Typing :: Typed"
 ]
-dependencies = ['cffi>=1.0.0']
 optional-dependencies = {docs= ["sphinx"]}
 
 [project.urls]


### PR DESCRIPTION
Currently, doing

`pip install .`

results silently in a non-working module.

```
$ python -c 'import nix; nix.eval("0")
...
ModuleNotFoundError: No module named 'nix._nix_api_store'
```

The reason is that using pip, it loads the backend from `pyproject.toml`, but CFFI is not in the `build-system.requires` array, hence it was not added as a setuptools plugin. This can be witnessed like so:

```
$ pip install -v .
...
Building wheels for collected packages: python-nix
  Running command Building wheel for python-nix (pyproject.toml)
  /tmp/pip-build-env-hzkiiza7/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py:265: UserWarning: Unknown distribution option: 'cffi_modules'
...
```

That is not an error but a warning, hence install succeeds when it should not.

This PR fixes the issue by adding CFFI (and pkgconfig) to the `build-system.requires` array.

```
$ export PKG_CONFIG_PATH="$(nix build github:tweag/nix/nix-c-bindings#default.dev --no-link --print-out-paths)/lib/pkgconfig"
$ nix shell nixpkgs#gcc nixpkgs#pkg-config
$ pip install .
$ python -c 'import nix; print(nix.eval("0"))'
0
```

This PR also updates the README, since adding this package to a project's dependencies is a bit tedious.